### PR TITLE
Performance improvement on flatten method

### DIFF
--- a/src/object/flatten.js
+++ b/src/object/flatten.js
@@ -17,27 +17,31 @@ function flatten(obj, separator = ".", prefix = "") {
     if (isCyclic(obj)) {
         throw new Error(CIRCULAR_REF_ERROR_MSG);
     }
-
-    let res = {};
-
+    
     const isObject = (r) => Object.getPrototypeOf(r) === Object.prototype;
+    
+    const _flatten = (obj, separator = ".", prefix = "") => {
+        let res = {};
 
-    Object.keys(obj).forEach(index => {
-        const val = obj[index];
-        const newIndex = prefix.length > 0
-            ? `${prefix}${separator}${index}`
-            : index;
+        Object.keys(obj).forEach(index => {
+            const val = obj[index];
+            const newIndex = prefix.length > 0
+                ? `${prefix}${separator}${index}`
+                : index;
 
-        if (isObject(val) || Array.isArray(val)) {
-            const objF = flatten(val, separator, newIndex);
-            res = Object.assign(res, objF);
-            return;
-        }
+            if (isObject(val) || Array.isArray(val)) {
+                const objF = _flatten(val, separator, newIndex);
+                res = Object.assign(res, objF);
+                return;
+            }
 
-        res[newIndex] = val;
-    });
+            res[newIndex] = val;
+        });
 
-    return res;
+        return res;
+    };
+
+    return _flatten(obj, separator, prefix);
 }
 
 module.exports = flatten;

--- a/src/object/isCyclic.js
+++ b/src/object/isCyclic.js
@@ -1,5 +1,3 @@
-const isObject = obj => typeof obj === "object";
-
 /**
  * Check if any given object has some kind of cyclic reference.
  *
@@ -8,19 +6,19 @@ const isObject = obj => typeof obj === "object";
  * @memberof object
  */
 function isCyclic(obj) {
-    const seenObjects = [];
-    const isSeen = obj => isObject(obj) && seenObjects.includes(obj);
+    let seenObjects = [];
 
     const detect = obj => {
-        if (isSeen(obj)) {
-            return true;
-        }
-
-        seenObjects.push(obj);
-
-        for (const key in Object.keys(obj)) {
-            if (detect(obj[key])) {
+        if (obj && typeof obj === "object") {
+            if (seenObjects.includes(obj)) {
                 return true;
+            }
+
+            seenObjects.push(obj);
+            for (const key in obj) {
+                if (obj.hasOwnProperty(key) && detect(obj[key])) {
+                    return true;
+                }
             }
         }
 

--- a/src/object/isCyclic.js
+++ b/src/object/isCyclic.js
@@ -1,3 +1,5 @@
+const isObject = obj => typeof obj === "object";
+
 /**
  * Check if any given object has some kind of cyclic reference.
  *
@@ -6,19 +8,19 @@
  * @memberof object
  */
 function isCyclic(obj) {
-    let seenObjects = [];
+    const seenObjects = [];
+    const isSeen = isObject(obj) && seenObjects.includes(obj);
 
     const detect = obj => {
-        if (obj && typeof obj === "object") {
-            if (seenObjects.includes(obj)) {
-                return true;
-            }
+        if (isSeen(obj)) {
+            return true;
+        }
 
-            seenObjects.push(obj);
-            for (const key in obj) {
-                if (obj.hasOwnProperty(key) && detect(obj[key])) {
-                    return true;
-                }
+        seenObjects.push(obj);
+
+        for (const key in Object.keys(obj)) {
+            if (detect(obj[key])) {
+                return true;
             }
         }
 

--- a/src/object/isCyclic.js
+++ b/src/object/isCyclic.js
@@ -9,7 +9,7 @@ const isObject = obj => typeof obj === "object";
  */
 function isCyclic(obj) {
     const seenObjects = [];
-    const isSeen = isObject(obj) && seenObjects.includes(obj);
+    const isSeen = obj => isObject(obj) && seenObjects.includes(obj);
 
     const detect = obj => {
         if (isSeen(obj)) {


### PR DESCRIPTION
- Removed `isCyclic` from every `flatten` method call since `isCyclic` perform an object scan, in theory, it's not necessary to perform a new object scan on the subset.